### PR TITLE
[#2] spring-security bean 생성

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,28 +12,33 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <spring-boot-starter-data-jpa-version>2.7.2</spring-boot-starter-data-jpa-version>
-        <jasypt-spring-boot-starter-version>3.0.4</jasypt-spring-boot-starter-version>
-        <spring-boot-starter-security.version>2.7.2</spring-boot-starter-security.version>
-    </properties>
 
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.1.RELEASE</version>
-    </parent>
+        <jasypt-spring-boot-starter-version>3.0.4</jasypt-spring-boot-starter-version>
+
+        <spring-boot-starter-data-jpa-version>2.7.2</spring-boot-starter-data-jpa-version>
+        <spring-boot-starter-web.version>2.7.1</spring-boot-starter-web.version>
+        <spring-boot-starter-security.version>2.7.2</spring-boot-starter-security.version>
+        <spring-boot-starter-test.version>2.7.1</spring-boot-starter-test.version>
+
+        <commons-lang3.version>3.12.0</commons-lang3.version>
+        <lombok.version>1.18.24</lombok.version>
+
+        <mysql-connector-java.version>8.0.29</mysql-connector-java.version>
+
+    </properties>
 
     <dependencies>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.24</version>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -43,15 +48,16 @@
             <version>${spring-boot-starter-security.version}</version>
         </dependency>
 
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring-boot-starter-web.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring-boot-starter-test.version}</version>
         </dependency>
 
         <dependency>
@@ -64,12 +70,7 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>runtime</scope>
+            <version>${mysql-connector-java.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
- component-based 시큐리티 설정 방식은 Spring Security 5.4부터 사용할 수 있다.
- spring parent 2.3.1.RELEASE에선 spring-security.version이 5.3.3.RELEASE 으로 설정되어있어 문제가 생김
- spring parent 태그 삭제하면 해결
Resolves #2